### PR TITLE
ci: CIワークフローにpathフィルターを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,24 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'terraform/**'
+      - 'pyproject.toml'
+      - '.pre-commit-config.yaml'
+      - '.python-version'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'terraform/**'
+      - 'pyproject.toml'
+      - '.pre-commit-config.yaml'
+      - '.python-version'
+      - '.github/workflows/ci.yml'
 
 
 jobs:


### PR DESCRIPTION
## Summary
- CIワークフローにpathフィルターを追加してドキュメントのみの変更時にCIが実行されないよう修正
- 以下のファイル変更時のみCIを実行:
  - `src/**` - ソースコード
  - `tests/**` - テストコード  
  - `terraform/**` - インフラ定義
  - `pyproject.toml` - Python設定
  - `.pre-commit-config.yaml` - pre-commit設定
  - `.python-version` - Pythonバージョン
  - `.github/workflows/ci.yml` - CI設定自体

## Test plan
- [x] ドキュメントのみの変更でCIが実行されないことを確認
- [x] ソースコード変更時にCIが正常実行されることを確認
- [x] 設定ファイル変更時にCIが正常実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

Close #17