### PR TITLE
feat: 通知先をNotionコメントからなんでもお知らせくんAPIに変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,4 +170,5 @@ jobs:
         terraform plan \
           -var="notion_api_key=${{ secrets.NOTION_API_KEY }}" \
           -var="notion_database_id=${{ secrets.NOTION_DATABASE_ID }}" \
-          -var="notion_page_id=${{ secrets.NOTION_PAGE_ID }}"
+          -var="notify_api_key=${{ secrets.NOTIFY_API_KEY }}" \
+          -var="notify_api_url=${{ secrets.NOTIFY_API_URL }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ known-first-party = ["shopping_reminder"]
 [tool.mypy]
 check_untyped_defs = true  # 関数の引数/戻り値の型をチェックする
 [[tool.mypy.overrides]]
-module = ["config", "notion_client", "models", "logger"]
+module = ["config", "notion_client", "notify_client", "models", "logger"]
 ignore_missing_imports = true
 
 # test

--- a/src/shopping_reminder/config.py
+++ b/src/shopping_reminder/config.py
@@ -20,7 +20,8 @@ class Config:
 
     notion_api_key: str
     notion_database_id: str
-    notion_page_id: str
+    notify_api_key: str
+    notify_api_url: str
 
     def __init__(self) -> None:
         """環境変数から設定を読み込み"""
@@ -32,8 +33,11 @@ class Config:
         self.notion_database_id = self._get_required_env_var("NOTION_DATABASE_ID")
         logger.info(f"NOTION_DATABASE_ID: {self.notion_database_id}")
 
-        self.notion_page_id = self._get_required_env_var("NOTION_PAGE_ID")
-        logger.info(f"NOTION_PAGE_ID: {self.notion_page_id}")
+        self.notify_api_key = self._get_required_env_var("NOTIFY_API_KEY")
+        logger.info(f"NOTIFY_API_KEY loaded (length: {len(self.notify_api_key)} chars)")
+
+        self.notify_api_url = self._get_required_env_var("NOTIFY_API_URL")
+        logger.info(f"NOTIFY_API_URL: {self.notify_api_url}")
 
         logger.info("Configuration loaded successfully")
 
@@ -44,7 +48,8 @@ class Config:
 
         config.notion_api_key = cls._get_required_dict_value(config_dict, "NOTION_API_KEY")
         config.notion_database_id = cls._get_required_dict_value(config_dict, "NOTION_DATABASE_ID")
-        config.notion_page_id = cls._get_required_dict_value(config_dict, "NOTION_PAGE_ID")
+        config.notify_api_key = cls._get_required_dict_value(config_dict, "NOTIFY_API_KEY")
+        config.notify_api_url = cls._get_required_dict_value(config_dict, "NOTIFY_API_URL")
 
         return config
 
@@ -74,5 +79,6 @@ class Config:
             f"Config("
             f"notion_api_key=***HIDDEN***, "
             f"notion_database_id={self.notion_database_id}, "
-            f"notion_page_id={self.notion_page_id})"
+            f"notify_api_key=***HIDDEN***, "
+            f"notify_api_url={self.notify_api_url})"
         )

--- a/src/shopping_reminder/lambda_handler.py
+++ b/src/shopping_reminder/lambda_handler.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 
 from config import Config, ConfigError
 from notion_client import NotionClient
+from notify_client import NotifyClient
 from models import NotificationResult
 from logger import get_logger
 
@@ -15,6 +16,7 @@ class ShoppingReminderProcessor:
     def __init__(self, config: Config) -> None:
         self.config = config
         self.notion_client = NotionClient(config)
+        self.notify_client = NotifyClient(config)
         logger.info("ShoppingReminderProcessor initialized successfully")
 
     def process(self) -> NotificationResult:
@@ -30,9 +32,9 @@ class ShoppingReminderProcessor:
             for item in unchecked_items:
                 logger.info(f"Unchecked item: {item.name} (ID: {item.id})")
 
-            # 2. コメントを作成（未チェック項目がない場合も含む）
-            logger.info("Creating comment notification")
-            result = self.notion_client.create_comment(unchecked_items)
+            # 2. 通知を送信（未チェック項目がない場合も含む）
+            logger.info("Sending notification")
+            result = self.notify_client.send_notification(unchecked_items)
 
             if result.success:
                 logger.info(f"Process completed successfully: {result.message}")

--- a/src/shopping_reminder/notify_client.py
+++ b/src/shopping_reminder/notify_client.py
@@ -1,0 +1,115 @@
+import json
+import urllib.request
+import urllib.error
+from typing import List, Dict, Any
+
+# Lambda環境での絶対インポート
+from models import ShoppingItem, NotificationResult
+from config import Config
+from logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class NotifyAPIError(Exception):
+    """通知API に関するエラー"""
+
+    pass
+
+
+class NotifyClient:
+    """なんでもお知らせくん API を操作するクライアント"""
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.notify_url = f"{config.notify_api_url}/notify"
+        logger.info("NotifyClient initialized")
+        logger.info(f"Notify URL: {self.notify_url}")
+
+    def send_notification(self, items: List[ShoppingItem]) -> NotificationResult:
+        """未チェック項目のリストを通知APIに送信"""
+        if not items:
+            logger.info("No unchecked items found - skipping notification")
+            return NotificationResult(
+                success=True, message="未チェック項目はありません。通知は送信されませんでした。"
+            )
+
+        try:
+            message = self._format_message(items)
+            logger.info(f"Sending notification message: {message}")
+
+            body = {"message": message}
+            response_data = self._make_post_request(self.notify_url, body)
+            logger.info(f"Notification response: {json.dumps(response_data)}")
+
+            logger.info(f"Notification sent successfully for {len(items)} items")
+            return NotificationResult(
+                success=True, message=f"{len(items)}件の未チェック項目について通知を送信しました。"
+            )
+
+        except NotifyAPIError as e:
+            logger.exception(f"Failed to send notification: {str(e)}")
+            return NotificationResult(
+                success=False, message="通知の送信に失敗しました。", error=str(e)
+            )
+
+    def _format_message(self, items: List[ShoppingItem]) -> str:
+        """通知用のメッセージを作成"""
+        count = len(items)
+        message = f"🛒 {count}件の未チェック項目があります:\n\n"
+
+        for item in items:
+            message += f"• {item.name}\n"
+
+        message += "\n買い忘れがないよう確認をお願いします！"
+        return message
+
+    def _make_post_request(self, url: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        """通知APIにPOSTリクエストを送信"""
+        logger.info(f"Making POST request to: {url}")
+
+        json_data = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        logger.info(f"Request data size: {len(json_data)} bytes")
+
+        request = urllib.request.Request(
+            url,
+            data=json_data,
+            headers={
+                "x-api-key": self.config.notify_api_key,
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+
+        logger.info("Sending request to Notify API...")
+
+        try:
+            with urllib.request.urlopen(request) as response:
+                response_data = response.read()
+                status_code = response.getcode()
+
+                logger.info(f"Response status code: {status_code}")
+                logger.info(f"Response data size: {len(response_data)} bytes")
+
+                if status_code == 200:
+                    decoded_response = json.loads(response_data.decode("utf-8"))
+                    logger.info("Request completed successfully")
+                    return decoded_response
+                else:
+                    error_message = response_data.decode("utf-8")
+                    logger.error(f"API request failed with status {status_code}")
+                    logger.error(f"Error response: {error_message}")
+                    raise NotifyAPIError(
+                        f"API request failed with status {status_code}: {error_message}"
+                    )
+
+        except urllib.error.HTTPError as e:
+            error_message = e.read().decode("utf-8") if e.fp else "Unknown error"
+            logger.exception(f"HTTP error occurred: {e.code} - {error_message}")
+            raise NotifyAPIError(f"HTTP error {e.code}: {error_message}") from e
+        except urllib.error.URLError as e:
+            logger.exception(f"URL error occurred: {e.reason}")
+            raise NotifyAPIError(f"URL error: {e.reason}") from e
+        except json.JSONDecodeError as e:
+            logger.exception(f"JSON decode error occurred: {e}")
+            raise NotifyAPIError(f"JSON decode error: {e}") from e

--- a/src/shopping_reminder/notion_client.py
+++ b/src/shopping_reminder/notion_client.py
@@ -4,7 +4,7 @@ import urllib.parse
 from typing import List, Dict, Any
 
 # Lambda環境での絶対インポート
-from models import ShoppingItem, NotionDatabaseItem, NotificationResult
+from models import ShoppingItem, NotionDatabaseItem
 from config import Config
 from logger import get_logger
 
@@ -25,7 +25,6 @@ class NotionClient:
         self.base_url = "https://api.notion.com/v1"
         logger.info("NotionClient initialized")
         logger.info(f"Database ID: {config.notion_database_id}")
-        logger.info(f"Page ID: {config.notion_page_id}")
 
     def query_unchecked_items(self) -> List[ShoppingItem]:
         """未チェック項目をデータベースから取得"""
@@ -73,55 +72,9 @@ class NotionClient:
         logger.info(f"Query completed. Total items found: {len(results)}")
         return results
 
-    def create_comment(self, items: List[ShoppingItem]) -> NotificationResult:
-        """未チェック項目のリストからコメントを作成"""
-        if not items:
-            logger.info("No unchecked items found - skipping comment creation")
-            return NotificationResult(
-                success=True, message="未チェック項目はありません。通知は送信されませんでした。"
-            )
-
-        try:
-            url = f"{self.base_url}/comments"
-            logger.info(f"Creating comment at: {url}")
-
-            message = self._format_comment_message(items)
-            logger.info(f"Comment message: {message}")
-
-            body = {
-                "parent": {"page_id": self.config.notion_page_id},
-                "rich_text": [{"type": "text", "text": {"content": message}}],
-            }
-
-            logger.info(f"Comment request body: {json.dumps(body)}")
-            response_data = self._make_post_request(url, body)
-            logger.info(f"Comment creation response: {json.dumps(response_data)}")
-
-            logger.info(f"Comment created successfully for {len(items)} items")
-            return NotificationResult(
-                success=True, message=f"{len(items)}件の未チェック項目について通知を送信しました。"
-            )
-
-        except NotionAPIError as e:
-            logger.exception(f"Failed to create comment: {str(e)}")
-            return NotificationResult(
-                success=False, message="コメントの作成に失敗しました。", error=str(e)
-            )
-
     def _build_filter_for_unchecked_items(self) -> Dict[str, Any]:
         """未チェック項目を取得するためのフィルターを構築"""
         return {"property": "完了", "checkbox": {"equals": False}}
-
-    def _format_comment_message(self, items: List[ShoppingItem]) -> str:
-        """コメント用のメッセージを作成"""
-        count = len(items)
-        message = f"🛒 {count}件の未チェック項目があります:\n\n"
-
-        for item in items:
-            message += f"• {item.name}\n"
-
-        message += "\n買い忘れがないよう確認をお願いします！"
-        return message
 
     def _make_post_request(self, url: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Notion APIにPOSTリクエストを送信"""

--- a/terraform/environments/production/README.md
+++ b/terraform/environments/production/README.md
@@ -49,7 +49,10 @@ python -m zipfile -c dist/lambda_function.zip src/shopping_reminder/*
 # Notion API設定
 notion_api_key     = "secret_xxxxxxxxxxxx"  # NotionのIntegrationから取得
 notion_database_id = "your-database-id"     # ショッピングリストデータベースのID
-notion_page_id     = "your-page-id"         # コメント投稿先ページのID
+
+# 通知API設定
+notify_api_key = "your-notify-api-key"      # なんでもお知らせくんAPIキー
+notify_api_url = "https://your-api-url"     # なんでもお知らせくんAPIのベースURL
 
 # Lambda設定
 lambda_function_name = "shopping-reminder"
@@ -262,9 +265,10 @@ environment {
 | <a name="input_lambda_function_name"></a> [lambda\_function\_name](#input\_lambda\_function\_name) | Name of the Lambda function | `string` | `"shopping-reminder"` | no |
 | <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Lambda function memory size in MB | `number` | `128` | no |
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Lambda function timeout in seconds | `number` | `30` | no |
+| <a name="input_notify_api_key"></a> [notify\_api\_key](#input\_notify\_api\_key) | API key for the notification service | `string` | n/a | yes |
+| <a name="input_notify_api_url"></a> [notify\_api\_url](#input\_notify\_api\_url) | Base URL of the notification API | `string` | n/a | yes |
 | <a name="input_notion_api_key"></a> [notion\_api\_key](#input\_notion\_api\_key) | Notion API key for accessing the workspace | `string` | n/a | yes |
 | <a name="input_notion_database_id"></a> [notion\_database\_id](#input\_notion\_database\_id) | ID of the Notion database containing shopping list items | `string` | n/a | yes |
-| <a name="input_notion_page_id"></a> [notion\_page\_id](#input\_notion\_page\_id) | ID of the Notion page where comments will be posted | `string` | n/a | yes |
 | <a name="input_output_zip_path"></a> [output\_zip\_path](#input\_output\_zip\_path) | Path where the Lambda deployment zip file will be created | `string` | `"../../../dist/lambda_function.zip"` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the AWS Resource Group | `string` | `"shopping-reminder-resources"` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | EventBridge schedule expression for the reminder (JST 17:00 = UTC 08:00) | `string` | `"cron(0 8 * * ? *)"` | no |

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -12,7 +12,10 @@ module "shopping_reminder" {
   # Notion configuration
   notion_api_key     = var.notion_api_key
   notion_database_id = var.notion_database_id
-  notion_page_id     = var.notion_page_id
+
+  # Notification API configuration
+  notify_api_key = var.notify_api_key
+  notify_api_url = var.notify_api_url
 
   # Lambda configuration
   lambda_function_name    = var.lambda_function_name

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -9,8 +9,14 @@ variable "notion_database_id" {
   type        = string
 }
 
-variable "notion_page_id" {
-  description = "ID of the Notion page where comments will be posted"
+variable "notify_api_key" {
+  description = "API key for the notification service"
+  type        = string
+  sensitive   = true
+}
+
+variable "notify_api_url" {
+  description = "Base URL of the notification API"
   type        = string
 }
 

--- a/terraform/modules/shopping-reminder/.terraform.lock.hcl
+++ b/terraform/modules/shopping-reminder/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.92"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/modules/shopping-reminder/README.md
+++ b/terraform/modules/shopping-reminder/README.md
@@ -19,7 +19,8 @@ module "shopping_reminder" {
   # 必須変数
   notion_api_key      = var.notion_api_key
   notion_database_id  = var.notion_database_id
-  notion_page_id      = var.notion_page_id
+  notify_api_key      = var.notify_api_key
+  notify_api_url      = var.notify_api_url
   lambda_zip_path     = var.lambda_zip_path
   lambda_source_code_hash = var.lambda_source_code_hash
 
@@ -84,7 +85,7 @@ sequenceDiagram
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.92 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
 
 ## Modules
 
@@ -118,9 +119,10 @@ No modules.
 | <a name="input_lambda_source_code_hash"></a> [lambda\_source\_code\_hash](#input\_lambda\_source\_code\_hash) | Base64 encoded hash of the Lambda zip file | `string` | n/a | yes |
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Lambda function timeout in seconds | `number` | `30` | no |
 | <a name="input_lambda_zip_path"></a> [lambda\_zip\_path](#input\_lambda\_zip\_path) | Path to the Lambda deployment zip file | `string` | n/a | yes |
+| <a name="input_notify_api_key"></a> [notify\_api\_key](#input\_notify\_api\_key) | API key for the notification service | `string` | n/a | yes |
+| <a name="input_notify_api_url"></a> [notify\_api\_url](#input\_notify\_api\_url) | Base URL of the notification API | `string` | n/a | yes |
 | <a name="input_notion_api_key"></a> [notion\_api\_key](#input\_notion\_api\_key) | Notion API key for accessing the workspace | `string` | n/a | yes |
 | <a name="input_notion_database_id"></a> [notion\_database\_id](#input\_notion\_database\_id) | ID of the Notion database containing shopping list items | `string` | n/a | yes |
-| <a name="input_notion_page_id"></a> [notion\_page\_id](#input\_notion\_page\_id) | ID of the Notion page where comments will be posted | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the AWS Resource Group | `string` | `"shopping-reminder-resources"` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | EventBridge schedule expression for the reminder (JST 17:00 = UTC 08:00) | `string` | `"cron(0 8 * * ? *)"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | <pre>{<br/>  "ManagedBy": "terraform",<br/>  "Project": "shopping-reminder"<br/>}</pre> | no |
@@ -146,7 +148,7 @@ No modules.
 ## セキュリティ
 
 - **IAMロール**: 最小権限の原則に従い、CloudWatch Logsの作成・書き込み権限のみ
-- **Sensitive変数**: `notion_api_key`は`sensitive = true`でマーク
+- **Sensitive変数**: `notion_api_key`と`notify_api_key`は`sensitive = true`でマーク
 - **VPC**: 不要なVPC設定は省略し、シンプルな構成を維持
 
 ## 監視とトラブルシューティング

--- a/terraform/modules/shopping-reminder/main.tf
+++ b/terraform/modules/shopping-reminder/main.tf
@@ -37,7 +37,8 @@ resource "aws_lambda_function" "shopping_reminder" {
     variables = {
       NOTION_API_KEY     = var.notion_api_key
       NOTION_DATABASE_ID = var.notion_database_id
-      NOTION_PAGE_ID     = var.notion_page_id
+      NOTIFY_API_KEY     = var.notify_api_key
+      NOTIFY_API_URL     = var.notify_api_url
     }
   }
 

--- a/terraform/modules/shopping-reminder/variables.tf
+++ b/terraform/modules/shopping-reminder/variables.tf
@@ -9,8 +9,14 @@ variable "notion_database_id" {
   type        = string
 }
 
-variable "notion_page_id" {
-  description = "ID of the Notion page where comments will be posted"
+variable "notify_api_key" {
+  description = "API key for the notification service"
+  type        = string
+  sensitive   = true
+}
+
+variable "notify_api_url" {
+  description = "Base URL of the notification API"
   type        = string
 }
 

--- a/tests/shopping_reminder/test_config.py
+++ b/tests/shopping_reminder/test_config.py
@@ -12,18 +12,24 @@ class TestConfig:
             {
                 "NOTION_API_KEY": "secret-key-123",
                 "NOTION_DATABASE_ID": "database-123",
-                "NOTION_PAGE_ID": "page-123",
+                "NOTIFY_API_KEY": "notify-key-123",
+                "NOTIFY_API_URL": "https://example.com/prod",
             },
         ):
             config = Config()
             assert config.notion_api_key == "secret-key-123"
             assert config.notion_database_id == "database-123"
-            assert config.notion_page_id == "page-123"
+            assert config.notify_api_key == "notify-key-123"
+            assert config.notify_api_url == "https://example.com/prod"
 
     def test_config_creation_missing_api_key(self) -> None:
         with patch.dict(
             os.environ,
-            {"NOTION_DATABASE_ID": "database-123", "NOTION_PAGE_ID": "page-123"},
+            {
+                "NOTION_DATABASE_ID": "database-123",
+                "NOTIFY_API_KEY": "notify-key-123",
+                "NOTIFY_API_URL": "https://example.com/prod",
+            },
             clear=True,
         ):
             with pytest.raises(ConfigError) as exc_info:
@@ -33,22 +39,44 @@ class TestConfig:
     def test_config_creation_missing_database_id(self) -> None:
         with patch.dict(
             os.environ,
-            {"NOTION_API_KEY": "secret-key-123", "NOTION_PAGE_ID": "page-123"},
+            {
+                "NOTION_API_KEY": "secret-key-123",
+                "NOTIFY_API_KEY": "notify-key-123",
+                "NOTIFY_API_URL": "https://example.com/prod",
+            },
             clear=True,
         ):
             with pytest.raises(ConfigError) as exc_info:
                 Config()
             assert "NOTION_DATABASE_ID" in str(exc_info.value)
 
-    def test_config_creation_missing_page_id(self) -> None:
+    def test_config_creation_missing_notify_api_key(self) -> None:
         with patch.dict(
             os.environ,
-            {"NOTION_API_KEY": "secret-key-123", "NOTION_DATABASE_ID": "database-123"},
+            {
+                "NOTION_API_KEY": "secret-key-123",
+                "NOTION_DATABASE_ID": "database-123",
+                "NOTIFY_API_URL": "https://example.com/prod",
+            },
             clear=True,
         ):
             with pytest.raises(ConfigError) as exc_info:
                 Config()
-            assert "NOTION_PAGE_ID" in str(exc_info.value)
+            assert "NOTIFY_API_KEY" in str(exc_info.value)
+
+    def test_config_creation_missing_notify_api_url(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "NOTION_API_KEY": "secret-key-123",
+                "NOTION_DATABASE_ID": "database-123",
+                "NOTIFY_API_KEY": "notify-key-123",
+            },
+            clear=True,
+        ):
+            with pytest.raises(ConfigError) as exc_info:
+                Config()
+            assert "NOTIFY_API_URL" in str(exc_info.value)
 
     def test_config_creation_empty_env_vars(self) -> None:
         with patch.dict(
@@ -56,7 +84,8 @@ class TestConfig:
             {
                 "NOTION_API_KEY": "",
                 "NOTION_DATABASE_ID": "database-123",
-                "NOTION_PAGE_ID": "page-123",
+                "NOTIFY_API_KEY": "notify-key-123",
+                "NOTIFY_API_URL": "https://example.com/prod",
             },
         ):
             with pytest.raises(ConfigError) as exc_info:
@@ -69,7 +98,8 @@ class TestConfig:
             {
                 "NOTION_API_KEY": "  ",
                 "NOTION_DATABASE_ID": "database-123",
-                "NOTION_PAGE_ID": "page-123",
+                "NOTIFY_API_KEY": "notify-key-123",
+                "NOTIFY_API_URL": "https://example.com/prod",
             },
         ):
             with pytest.raises(ConfigError) as exc_info:
@@ -82,7 +112,8 @@ class TestConfig:
             {
                 "NOTION_API_KEY": "secret-key-123",
                 "NOTION_DATABASE_ID": "database-123",
-                "NOTION_PAGE_ID": "page-123",
+                "NOTIFY_API_KEY": "notify-key-123",
+                "NOTIFY_API_URL": "https://example.com/prod",
             },
         ):
             config = Config()
@@ -93,37 +124,44 @@ class TestConfig:
         config_dict = {
             "NOTION_API_KEY": "secret-key-456",
             "NOTION_DATABASE_ID": "database-456",
-            "NOTION_PAGE_ID": "page-456",
+            "NOTIFY_API_KEY": "notify-key-456",
+            "NOTIFY_API_URL": "https://example.com/prod",
         }
         config = Config.from_dict(config_dict)
         assert config.notion_api_key == "secret-key-456"
         assert config.notion_database_id == "database-456"
-        assert config.notion_page_id == "page-456"
+        assert config.notify_api_key == "notify-key-456"
+        assert config.notify_api_url == "https://example.com/prod"
 
     def test_config_from_dict_missing_key(self) -> None:
-        config_dict = {"NOTION_DATABASE_ID": "database-456", "NOTION_PAGE_ID": "page-456"}
+        config_dict = {
+            "NOTION_DATABASE_ID": "database-456",
+            "NOTIFY_API_KEY": "notify-key-456",
+            "NOTIFY_API_URL": "https://example.com/prod",
+        }
         with pytest.raises(ConfigError) as exc_info:
             Config.from_dict(config_dict)
         assert "NOTION_API_KEY" in str(exc_info.value)
 
     def test_config_from_dict_with_integer_values(self) -> None:
-        """数値が渡された場合の文字列変換テスト（行50をカバー）"""
+        """数値が渡された場合の文字列変換テスト"""
         config_dict = {
             "NOTION_API_KEY": 123456,  # 数値
             "NOTION_DATABASE_ID": "database-456",
-            "NOTION_PAGE_ID": "page-456",
+            "NOTIFY_API_KEY": "notify-key-456",
+            "NOTIFY_API_URL": "https://example.com/prod",
         }
         config = Config.from_dict(config_dict)
         assert config.notion_api_key == "123456"  # 文字列に変換される
         assert config.notion_database_id == "database-456"
-        assert config.notion_page_id == "page-456"
 
     def test_config_from_dict_with_whitespace_only_value(self) -> None:
-        """空白のみの値の場合のテスト（行49をカバー）"""
+        """空白のみの値の場合のテスト"""
         config_dict = {
             "NOTION_API_KEY": "   ",  # 空白のみ
             "NOTION_DATABASE_ID": "database-456",
-            "NOTION_PAGE_ID": "page-456",
+            "NOTIFY_API_KEY": "notify-key-456",
+            "NOTIFY_API_URL": "https://example.com/prod",
         }
         with pytest.raises(ConfigError) as exc_info:
             Config.from_dict(config_dict)
@@ -136,15 +174,17 @@ class TestConfig:
             {
                 "NOTION_API_KEY": "secret-key-123",
                 "NOTION_DATABASE_ID": "database-123",
-                "NOTION_PAGE_ID": "page-123",
+                "NOTIFY_API_KEY": "notify-key-123",
+                "NOTIFY_API_URL": "https://example.com/prod",
             },
         ):
             config = Config()
             config_str = str(config)
             assert "secret-key-123" not in config_str
+            assert "notify-key-123" not in config_str
             assert "*****" in config_str or "hidden" in config_str.lower()
             assert "database-123" in config_str
-            assert "page-123" in config_str
+            assert "https://example.com/prod" in config_str
 
 
 class TestConfigError:

--- a/tests/shopping_reminder/test_lambda_handler.py
+++ b/tests/shopping_reminder/test_lambda_handler.py
@@ -14,7 +14,8 @@ class TestShoppingReminderProcessor:
             {
                 "NOTION_API_KEY": "secret_test_key",
                 "NOTION_DATABASE_ID": "test_database_id",
-                "NOTION_PAGE_ID": "test_page_id",
+                "NOTIFY_API_KEY": "test_notify_key",
+                "NOTIFY_API_URL": "https://example.com/prod",
             }
         )
         self.processor = ShoppingReminderProcessor(self.config)
@@ -22,16 +23,22 @@ class TestShoppingReminderProcessor:
     def test_processor_initialization(self) -> None:
         assert self.processor.config == self.config
         assert self.processor.notion_client is not None
+        assert self.processor.notify_client is not None
 
+    @patch("src.shopping_reminder.lambda_handler.NotifyClient")
     @patch("src.shopping_reminder.lambda_handler.NotionClient")
-    def test_process_with_unchecked_items(self, mock_notion_client_class: Mock) -> None:
+    def test_process_with_unchecked_items(
+        self, mock_notion_client_class: Mock, mock_notify_client_class: Mock
+    ) -> None:
         # モックの設定
-        mock_client = Mock()
-        mock_notion_client_class.return_value = mock_client
+        mock_notion = Mock()
+        mock_notion_client_class.return_value = mock_notion
+        mock_notify = Mock()
+        mock_notify_client_class.return_value = mock_notify
 
         unchecked_items = [ShoppingItem("1", "牛乳", False), ShoppingItem("2", "パン", False)]
-        mock_client.query_unchecked_items.return_value = unchecked_items
-        mock_client.create_comment.return_value = NotificationResult(
+        mock_notion.query_unchecked_items.return_value = unchecked_items
+        mock_notify.send_notification.return_value = NotificationResult(
             success=True, message="2件の未チェック項目について通知を送信しました。"
         )
 
@@ -40,16 +47,21 @@ class TestShoppingReminderProcessor:
 
         assert result.success is True
         assert "2件の未チェック項目について通知を送信しました" in result.message
-        mock_client.query_unchecked_items.assert_called_once()
-        mock_client.create_comment.assert_called_once_with(unchecked_items)
+        mock_notion.query_unchecked_items.assert_called_once()
+        mock_notify.send_notification.assert_called_once_with(unchecked_items)
 
+    @patch("src.shopping_reminder.lambda_handler.NotifyClient")
     @patch("src.shopping_reminder.lambda_handler.NotionClient")
-    def test_process_with_no_unchecked_items(self, mock_notion_client_class: Mock) -> None:
-        mock_client = Mock()
-        mock_notion_client_class.return_value = mock_client
+    def test_process_with_no_unchecked_items(
+        self, mock_notion_client_class: Mock, mock_notify_client_class: Mock
+    ) -> None:
+        mock_notion = Mock()
+        mock_notion_client_class.return_value = mock_notion
+        mock_notify = Mock()
+        mock_notify_client_class.return_value = mock_notify
 
-        mock_client.query_unchecked_items.return_value = []
-        mock_client.create_comment.return_value = NotificationResult(
+        mock_notion.query_unchecked_items.return_value = []
+        mock_notify.send_notification.return_value = NotificationResult(
             success=True, message="未チェック項目はありません。通知は送信されませんでした。"
         )
 
@@ -58,15 +70,19 @@ class TestShoppingReminderProcessor:
 
         assert result.success is True
         assert "未チェック項目はありません" in result.message
-        mock_client.query_unchecked_items.assert_called_once()
-        mock_client.create_comment.assert_called_once_with([])
+        mock_notion.query_unchecked_items.assert_called_once()
+        mock_notify.send_notification.assert_called_once_with([])
 
+    @patch("src.shopping_reminder.lambda_handler.NotifyClient")
     @patch("src.shopping_reminder.lambda_handler.NotionClient")
-    def test_process_with_query_error(self, mock_notion_client_class: Mock) -> None:
-        mock_client = Mock()
-        mock_notion_client_class.return_value = mock_client
+    def test_process_with_query_error(
+        self, mock_notion_client_class: Mock, mock_notify_client_class: Mock
+    ) -> None:
+        mock_notion = Mock()
+        mock_notion_client_class.return_value = mock_notion
+        mock_notify_client_class.return_value = Mock()
 
-        mock_client.query_unchecked_items.side_effect = Exception("データベースクエリエラー")
+        mock_notion.query_unchecked_items.side_effect = Exception("データベースクエリエラー")
 
         processor = ShoppingReminderProcessor(self.config)
         result = processor.process()
@@ -75,22 +91,27 @@ class TestShoppingReminderProcessor:
         assert "処理中にエラーが発生しました" in result.message
         assert "データベースクエリエラー" in result.error
 
+    @patch("src.shopping_reminder.lambda_handler.NotifyClient")
     @patch("src.shopping_reminder.lambda_handler.NotionClient")
-    def test_process_with_comment_creation_error(self, mock_notion_client_class: Mock) -> None:
-        mock_client = Mock()
-        mock_notion_client_class.return_value = mock_client
+    def test_process_with_notification_error(
+        self, mock_notion_client_class: Mock, mock_notify_client_class: Mock
+    ) -> None:
+        mock_notion = Mock()
+        mock_notion_client_class.return_value = mock_notion
+        mock_notify = Mock()
+        mock_notify_client_class.return_value = mock_notify
 
         unchecked_items = [ShoppingItem("1", "牛乳", False)]
-        mock_client.query_unchecked_items.return_value = unchecked_items
-        mock_client.create_comment.return_value = NotificationResult(
-            success=False, message="コメントの作成に失敗しました。", error="API key が無効です"
+        mock_notion.query_unchecked_items.return_value = unchecked_items
+        mock_notify.send_notification.return_value = NotificationResult(
+            success=False, message="通知の送信に失敗しました。", error="API key が無効です"
         )
 
         processor = ShoppingReminderProcessor(self.config)
         result = processor.process()
 
         assert result.success is False
-        assert "コメントの作成に失敗しました" in result.message
+        assert "通知の送信に失敗しました" in result.message
         assert "API key が無効です" in result.error
 
 

--- a/tests/shopping_reminder/test_notify_client.py
+++ b/tests/shopping_reminder/test_notify_client.py
@@ -1,0 +1,159 @@
+import json
+import urllib.error
+from typing import List
+from unittest.mock import Mock, patch
+
+from src.shopping_reminder.notify_client import NotifyClient, NotifyAPIError
+from src.shopping_reminder.models import ShoppingItem
+from src.shopping_reminder.config import Config
+
+
+class TestNotifyClient:
+    def setup_method(self) -> None:
+        """各テストメソッドの前に実行される"""
+        self.config = Config.from_dict(
+            {
+                "NOTION_API_KEY": "secret_test_key",
+                "NOTION_DATABASE_ID": "test_database_id",
+                "NOTIFY_API_KEY": "test_notify_key",
+                "NOTIFY_API_URL": "https://example.com/prod",
+            }
+        )
+        self.client = NotifyClient(self.config)
+
+    def test_notify_client_initialization(self) -> None:
+        assert self.client.config == self.config
+        assert self.client.notify_url == "https://example.com/prod/notify"
+
+    @patch("urllib.request.urlopen")
+    def test_send_notification_success(self, mock_urlopen: Mock) -> None:
+        mock_response_data = {"message": "Successfully sent 1 message(s)"}
+
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps(mock_response_data).encode("utf-8")
+        mock_response.getcode.return_value = 200
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        items = [ShoppingItem("1", "牛乳", False), ShoppingItem("2", "パン", False)]
+        result = self.client.send_notification(items)
+
+        assert result.success is True
+        assert "2件の未チェック項目について通知を送信しました" in result.message
+        assert result.error is None
+        mock_urlopen.assert_called_once()
+
+    @patch("urllib.request.urlopen")
+    def test_send_notification_empty_items(self, mock_urlopen: Mock) -> None:
+        items: List[ShoppingItem] = []
+        result = self.client.send_notification(items)
+
+        assert result.success is True
+        assert "未チェック項目はありません" in result.message
+        assert result.error is None
+        # APIが呼ばれないことを確認
+        mock_urlopen.assert_not_called()
+
+    @patch("urllib.request.urlopen")
+    def test_send_notification_api_error(self, mock_urlopen: Mock) -> None:
+        mock_response = Mock()
+        mock_response.getcode.return_value = 400
+        mock_response.read.return_value = b'{"message": "No message or messages key found"}'
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        items = [ShoppingItem("1", "牛乳", False)]
+        result = self.client.send_notification(items)
+
+        assert result.success is False
+        assert "通知の送信に失敗しました" in result.message
+        assert "400" in result.error
+
+    @patch("urllib.request.urlopen")
+    def test_send_notification_http_error(self, mock_urlopen: Mock) -> None:
+        http_error = urllib.error.HTTPError(
+            url="https://example.com/prod/notify",
+            code=500,
+            msg="Internal Server Error",
+            hdrs={},
+            fp=None,
+        )
+        mock_urlopen.side_effect = http_error
+
+        items = [ShoppingItem("1", "牛乳", False)]
+        result = self.client.send_notification(items)
+
+        assert result.success is False
+        assert "通知の送信に失敗しました" in result.message
+        assert "HTTP error 500" in result.error
+
+    @patch("urllib.request.urlopen")
+    def test_send_notification_url_error(self, mock_urlopen: Mock) -> None:
+        url_error = urllib.error.URLError("Connection refused")
+        mock_urlopen.side_effect = url_error
+
+        items = [ShoppingItem("1", "牛乳", False)]
+        result = self.client.send_notification(items)
+
+        assert result.success is False
+        assert "通知の送信に失敗しました" in result.message
+        assert "URL error" in result.error
+
+    @patch("urllib.request.urlopen")
+    def test_send_notification_json_decode_error(self, mock_urlopen: Mock) -> None:
+        mock_response = Mock()
+        mock_response.read.return_value = b"invalid json{"
+        mock_response.getcode.return_value = 200
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        items = [ShoppingItem("1", "牛乳", False)]
+        result = self.client.send_notification(items)
+
+        assert result.success is False
+        assert "通知の送信に失敗しました" in result.message
+        assert "JSON decode error" in result.error
+
+    def test_format_message_single_item(self) -> None:
+        items = [ShoppingItem("1", "牛乳", False)]
+        message = self.client._format_message(items)
+
+        assert "1件の未チェック項目があります" in message
+        assert "• 牛乳" in message
+        assert "確認をお願いします" in message
+
+    def test_format_message_multiple_items(self) -> None:
+        items = [
+            ShoppingItem("1", "牛乳", False),
+            ShoppingItem("2", "パン", False),
+            ShoppingItem("3", "卵", False),
+        ]
+        message = self.client._format_message(items)
+
+        assert "3件の未チェック項目があります" in message
+        assert "• 牛乳" in message
+        assert "• パン" in message
+        assert "• 卵" in message
+
+    @patch("urllib.request.urlopen")
+    def test_request_uses_api_key_header(self, mock_urlopen: Mock) -> None:
+        """x-api-key ヘッダーが正しく設定されることを確認"""
+        mock_response_data = {"message": "Successfully sent 1 message(s)"}
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps(mock_response_data).encode("utf-8")
+        mock_response.getcode.return_value = 200
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        items = [ShoppingItem("1", "牛乳", False)]
+        self.client.send_notification(items)
+
+        call_args = mock_urlopen.call_args
+        request = call_args[0][0]
+        assert request.get_header("X-api-key") == "test_notify_key"
+
+
+class TestNotifyAPIError:
+    def test_notify_api_error_creation(self) -> None:
+        error = NotifyAPIError("Test error message")
+        assert str(error) == "Test error message"
+
+    def test_notify_api_error_inheritance(self) -> None:
+        error = NotifyAPIError("Test error")
+        assert isinstance(error, Exception)

--- a/tests/shopping_reminder/test_notion_client.py
+++ b/tests/shopping_reminder/test_notion_client.py
@@ -1,10 +1,8 @@
 import json
-from typing import List
 from unittest.mock import Mock, patch
 import pytest
 
 from src.shopping_reminder.notion_client import NotionClient, NotionAPIError
-from src.shopping_reminder.models import ShoppingItem
 from src.shopping_reminder.config import Config
 
 
@@ -15,7 +13,8 @@ class TestNotionClient:
             {
                 "NOTION_API_KEY": "secret_test_key",
                 "NOTION_DATABASE_ID": "test_database_id",
-                "NOTION_PAGE_ID": "test_page_id",
+                "NOTIFY_API_KEY": "test_notify_key",
+                "NOTIFY_API_URL": "https://example.com/prod",
             }
         )
         self.client = NotionClient(self.config)
@@ -152,7 +151,7 @@ class TestNotionClient:
 
     @patch("urllib.request.urlopen")
     def test_url_error(self, mock_urlopen: Mock) -> None:
-        """URLError の場合のテスト（行139をカバー）"""
+        """URLError の場合のテスト"""
         import urllib.error
 
         url_error = urllib.error.URLError("Connection refused")
@@ -166,7 +165,7 @@ class TestNotionClient:
 
     @patch("urllib.request.urlopen")
     def test_json_decode_error(self, mock_urlopen: Mock) -> None:
-        """JSONDecodeError の場合のテスト（行141をカバー）"""
+        """JSONDecodeError の場合のテスト"""
         mock_response = Mock()
         mock_response.read.return_value = b"invalid json{"
         mock_response.getcode.return_value = 200
@@ -177,76 +176,11 @@ class TestNotionClient:
 
         assert "JSON decode error" in str(exc_info.value)
 
-    @patch("urllib.request.urlopen")
-    def test_create_comment_success(self, mock_urlopen: Mock) -> None:
-        mock_response_data = {
-            "id": "comment123",
-            "parent": {"page_id": "test_page_id"},
-            "created_time": "2023-01-01T00:00:00.000Z",
-        }
-
-        mock_response = Mock()
-        mock_response.read.return_value = json.dumps(mock_response_data).encode("utf-8")
-        mock_response.getcode.return_value = 200
-        mock_urlopen.return_value.__enter__.return_value = mock_response
-
-        items = [ShoppingItem("1", "牛乳", False), ShoppingItem("2", "パン", False)]
-        result = self.client.create_comment(items)
-
-        assert result.success is True
-        assert "2件の未チェック項目" in result.message
-        assert result.error is None
-
-    @patch("urllib.request.urlopen")
-    def test_create_comment_empty_items(self, mock_urlopen: Mock) -> None:
-        items: List[ShoppingItem] = []
-        result = self.client.create_comment(items)
-
-        assert result.success is True
-        assert "未チェック項目はありません" in result.message
-        assert result.error is None
-        # APIが呼ばれないことを確認
-        mock_urlopen.assert_not_called()
-
-    @patch("urllib.request.urlopen")
-    def test_create_comment_api_error(self, mock_urlopen: Mock) -> None:
-        mock_response = Mock()
-        mock_response.getcode.return_value = 400
-        mock_response.read.return_value = b'{"message": "Bad request"}'
-        mock_urlopen.return_value.__enter__.return_value = mock_response
-
-        items = [ShoppingItem("1", "牛乳", False)]
-        result = self.client.create_comment(items)
-
-        assert result.success is False
-        assert "コメントの作成に失敗" in result.message
-        assert "400" in result.error
-
     def test_build_filter_for_unchecked_items(self) -> None:
         filter_obj = self.client._build_filter_for_unchecked_items()
 
         expected_filter = {"property": "完了", "checkbox": {"equals": False}}
         assert filter_obj == expected_filter
-
-    def test_format_comment_message_single_item(self) -> None:
-        items = [ShoppingItem("1", "牛乳", False)]
-        message = self.client._format_comment_message(items)
-
-        assert "1件の未チェック項目があります" in message
-        assert "• 牛乳" in message
-
-    def test_format_comment_message_multiple_items(self) -> None:
-        items = [
-            ShoppingItem("1", "牛乳", False),
-            ShoppingItem("2", "パン", False),
-            ShoppingItem("3", "卵", False),
-        ]
-        message = self.client._format_comment_message(items)
-
-        assert "3件の未チェック項目があります" in message
-        assert "• 牛乳" in message
-        assert "• パン" in message
-        assert "• 卵" in message
 
 
 class TestNotionAPIError:


### PR DESCRIPTION
## Summary

- 新しいメッセージ通知API（なんでもお知らせくん）へ通知先を変更
- `NotifyClient` を新規作成（`x-api-key` ヘッダーによる認証、`POST /notify` でLINE通知）
- `NotionClient` からコメント作成関連メソッド（`create_comment`, `_format_comment_message`）を削除
- `Config` を更新: `NOTION_PAGE_ID` を廃止し `NOTIFY_API_KEY` / `NOTIFY_API_URL` を追加
- Terraform 変数も同様に更新（モジュール・本番環境）

## Test plan

- [x] pre-commitフックが全て通る
- [x] 全テストが成功（61 passed）
- [x] ruff・mypy エラーなし
- [x] `test_notify_client.py` を新規追加（12テスト）

🤖 Generated with [Claude Code](https://claude.ai/code)