### PR TITLE
fix: CD の terraform apply 変数を notify API に対応

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,7 +73,8 @@ jobs:
         terraform apply \
           -var="notion_api_key=${{ secrets.NOTION_API_KEY }}" \
           -var="notion_database_id=${{ secrets.NOTION_DATABASE_ID }}" \
-          -var="notion_page_id=${{ secrets.NOTION_PAGE_ID }}" \
+          -var="notify_api_key=${{ secrets.NOTIFY_API_KEY }}" \
+          -var="notify_api_url=${{ secrets.NOTIFY_API_URL }}" \
           -auto-approve
 
     - name: Test Lambda deployment


### PR DESCRIPTION
## Summary

- `terraform apply` で `notion_page_id` を渡していたが、この変数は削除済み
- `notify_api_key` / `notify_api_url` が渡されておらず、Terraform が対話入力待ちでハングしていた
- `NOTIFY_API_KEY` / `NOTIFY_API_URL` シークレットを使うよう修正

## Test plan

- [x] pre-commitフックが全て通る
- [x] CI チェックが通ること（Terraform Validation / Lint etc.）

🤖 Generated with [Claude Code](https://claude.ai/code)